### PR TITLE
Update lsb.nix by removing qt4 and python2 and updating foomatic_filters

### DIFF
--- a/modules/lsb.nix
+++ b/modules/lsb.nix
@@ -106,9 +106,6 @@
         at-spi2-core
         at-spi2-atk
 
-        ## Qt Libraries
-        qt4
-
         ## Sound libraries
         alsaLib
         openal
@@ -177,7 +174,6 @@
           utillinux
 
           # Languages
-          python2
           perl
           python3
 
@@ -196,7 +192,7 @@
           cups
 
           # Imaging
-          foomatic_filters
+          foomatic-filters
           ghostscript
         ] ++ libsFromPkgs pkgs
         ++ lib.optionals (config.environment.lsb.support32Bit)


### PR DESCRIPTION
This module is currently broken as-is since qt4 and python2 are no longer packaged for Nix and foomatic_filters is now called foomatic-filters.